### PR TITLE
Support MULTI_LINE_TEXT field

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PLUGINS_DIR=~/.terraform.d/plugins/darwin_amd64
+PLUGINS_DIR=~/.terraform.d/plugins/$(shell go env GOHOSTOS)_$(shell go env GOHOSTARCH)
 SOURCES=$(wildcard *.go)
 PKG_NAME=terraform-provider-kintone
 # TEST?=$$(go list ./ | grep -v 'vendor')

--- a/example/test.tf
+++ b/example/test.tf
@@ -7,6 +7,7 @@ resource "kintone_application" "test_application_1" {
 
   field = { code = "code_number" label = "number" type = "NUMBER" }
   field = { code = "code_title" label = "title" type = "SINGLE_LINE_TEXT" }
+  field = { code = "code_description" label = "description" type = "MULTI_LINE_TEXT" }
 
   status_enable = true
 

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -58,6 +59,7 @@ github.com/hashicorp/hcl2 v0.0.0-20181106230604-9aa28a1a0b53 h1:SaICs+P2pWJdPxk6
 github.com/hashicorp/hcl2 v0.0.0-20181106230604-9aa28a1a0b53/go.mod h1:RmdLUlY7zVg+hORWhQrL9Kyy1b23uMZUtkaRZnCvPYs=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 h1:fooK5IvDL/KIsi4LxF/JH68nVdrBSiGNPhS2JAQjtjo=
 github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250/go.mod h1:KHvg/R2/dPtaePb16oW4qIyzkMxXOL38xjRN64adsts=
+github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform v0.11.10 h1:XYZ/V+teSckRfZdwxsoP+66v0slHixe5Ai8wxqY/lfo=
 github.com/hashicorp/terraform v0.11.10/go.mod h1:uN1KUiT7Wdg61fPwsGXQwK3c8PmpIVZrt5Vcb1VrSoM=

--- a/kintone/client/api_client_impl.go
+++ b/kintone/client/api_client_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/naruta/terraform-provider-kintone/kintone"
 	"github.com/naruta/terraform-provider-kintone/kintone/raw_client"
+	"log"
 	"strconv"
 )
 
@@ -125,7 +126,10 @@ func (c *ApiClientImpl) FetchApplication(ctx context.Context, appId kintone.AppI
 	for _, p := range fieldsResp.Properties {
 		field, err := mapper.PropertyToField(&p.FieldProperty)
 		if err != nil {
-			return kintone.Application{}, err
+			// Ignore unknown fields
+			// TODO: return an error here once we support all field types
+			log.Printf("ignore: %v", err)
+			continue
 		}
 		fields = append(fields, field)
 	}

--- a/kintone/client/api_client_impl.go
+++ b/kintone/client/api_client_impl.go
@@ -3,9 +3,7 @@ package client
 import (
 	"context"
 	"github.com/naruta/terraform-provider-kintone/kintone"
-	"github.com/naruta/terraform-provider-kintone/kintone/field"
 	"github.com/naruta/terraform-provider-kintone/kintone/raw_client"
-	"github.com/pkg/errors"
 	"strconv"
 )
 
@@ -123,8 +121,9 @@ func (c *ApiClientImpl) FetchApplication(ctx context.Context, appId kintone.AppI
 	}
 
 	var fields []kintone.Field
+	mapper := fieldPropertyMapper{}
 	for _, p := range fieldsResp.Properties {
-		field, err := createFieldFromProperty(&p)
+		field, err := mapper.PropertyToField(&p)
 		if err != nil {
 			return kintone.Application{}, err
 		}
@@ -169,24 +168,12 @@ func (c *ApiClientImpl) FetchApplication(ctx context.Context, appId kintone.AppI
 	}, nil
 }
 
-func createFieldFromProperty(p *raw_client.GetAppFormFieldsRequestProperty) (kintone.Field, error) {
-	switch p.Type {
-	case "SINGLE_LINE_TEXT":
-		return field.NewSingleLineText(kintone.FieldCode(p.Code), p.Label), nil
-	case "NUMBER":
-		return field.NewNumber(kintone.FieldCode(p.Code), p.Label), nil
-	default:
-		return nil, errors.Errorf("unknown field type: %s", p.Type)
-	}
-}
-
 func (c *ApiClientImpl) CreatePreviewApplicationFormFields(ctx context.Context, appId kintone.AppId, revision kintone.Revision, fields []kintone.Field) (kintone.Revision, error) {
 	properties := map[string]raw_client.PostPreviewAppFormFieldsRequestProperty{}
+	mapper := fieldPropertyMapper{}
 	for _, field := range fields {
 		properties[field.Code().String()] = raw_client.PostPreviewAppFormFieldsRequestProperty{
-			Code:  field.Code().String(),
-			Label: field.Label(),
-			Type:  field.Type().String(),
+			FieldProperty: mapper.FieldToProperty(field),
 		}
 	}
 
@@ -203,11 +190,10 @@ func (c *ApiClientImpl) CreatePreviewApplicationFormFields(ctx context.Context, 
 
 func (c *ApiClientImpl) UpdatePreviewApplicationFormFields(ctx context.Context, appId kintone.AppId, revision kintone.Revision, fields []kintone.Field) (kintone.Revision, error) {
 	properties := map[string]raw_client.PutPreviewAppFormFieldsRequestProperty{}
+	mapper := fieldPropertyMapper{}
 	for _, field := range fields {
 		properties[field.Code().String()] = raw_client.PutPreviewAppFormFieldsRequestProperty{
-			Code:  field.Code().String(),
-			Label: field.Label(),
-			Type:  field.Type().String(),
+			FieldProperty: mapper.FieldToProperty(field),
 		}
 	}
 

--- a/kintone/client/api_client_impl.go
+++ b/kintone/client/api_client_impl.go
@@ -123,7 +123,7 @@ func (c *ApiClientImpl) FetchApplication(ctx context.Context, appId kintone.AppI
 	var fields []kintone.Field
 	mapper := fieldPropertyMapper{}
 	for _, p := range fieldsResp.Properties {
-		field, err := mapper.PropertyToField(&p)
+		field, err := mapper.PropertyToField(&p.FieldProperty)
 		if err != nil {
 			return kintone.Application{}, err
 		}

--- a/kintone/client/field_mapper.go
+++ b/kintone/client/field_mapper.go
@@ -1,0 +1,29 @@
+package client
+
+import (
+	"github.com/naruta/terraform-provider-kintone/kintone"
+	"github.com/naruta/terraform-provider-kintone/kintone/field"
+	"github.com/naruta/terraform-provider-kintone/kintone/raw_client"
+	"github.com/pkg/errors"
+)
+
+type fieldPropertyMapper struct{}
+
+func (m *fieldPropertyMapper) PropertyToField(p *raw_client.GetAppFormFieldsRequestProperty) (kintone.Field, error) {
+	switch p.Type {
+	case "SINGLE_LINE_TEXT":
+		return field.NewSingleLineText(kintone.FieldCode(p.Code), p.Label), nil
+	case "NUMBER":
+		return field.NewNumber(kintone.FieldCode(p.Code), p.Label), nil
+	default:
+		return nil, errors.Errorf("unknown field type: %s", p.Type)
+	}
+}
+
+func (m *fieldPropertyMapper) FieldToProperty(f kintone.Field) raw_client.FieldProperty {
+	return raw_client.FieldProperty{
+		Code:  f.Code().String(),
+		Label: f.Label(),
+		Type:  f.Type().String(),
+	}
+}

--- a/kintone/client/field_mapper.go
+++ b/kintone/client/field_mapper.go
@@ -9,7 +9,7 @@ import (
 
 type fieldPropertyMapper struct{}
 
-func (m *fieldPropertyMapper) PropertyToField(p *raw_client.GetAppFormFieldsRequestProperty) (kintone.Field, error) {
+func (m *fieldPropertyMapper) PropertyToField(p *raw_client.FieldProperty) (kintone.Field, error) {
 	switch p.Type {
 	case "SINGLE_LINE_TEXT":
 		return field.NewSingleLineText(kintone.FieldCode(p.Code), p.Label), nil

--- a/kintone/client/field_mapper.go
+++ b/kintone/client/field_mapper.go
@@ -13,6 +13,8 @@ func (m *fieldPropertyMapper) PropertyToField(p *raw_client.FieldProperty) (kint
 	switch p.Type {
 	case "SINGLE_LINE_TEXT":
 		return field.NewSingleLineText(kintone.FieldCode(p.Code), p.Label), nil
+	case "MULTI_LINE_TEXT":
+		return field.NewMultiLineText(kintone.FieldCode(p.Code), p.Label), nil
 	case "NUMBER":
 		return field.NewNumber(kintone.FieldCode(p.Code), p.Label), nil
 	default:

--- a/kintone/client/field_mapper_test.go
+++ b/kintone/client/field_mapper_test.go
@@ -21,6 +21,14 @@ func TestFieldPropertyMapper(t *testing.T) {
 			},
 		},
 		{
+			title: "MULTI_LINE_TEXT",
+			property: raw_client.FieldProperty{
+				Type:  "MULTI_LINE_TEXT",
+				Code:  "text-2",
+				Label: "🍣🍺",
+			},
+		},
+		{
 			title: "NUMBER",
 			property: raw_client.FieldProperty{
 				Type:  "NUMBER",

--- a/kintone/client/field_mapper_test.go
+++ b/kintone/client/field_mapper_test.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"github.com/naruta/terraform-provider-kintone/kintone/raw_client"
+	"reflect"
+	"testing"
+)
+
+func TestFieldPropertyMapper(t *testing.T) {
+	testCases := []struct {
+		title         string
+		property      raw_client.FieldProperty
+		shouldBeError bool
+	}{
+		{
+			title: "SINGLE_LINE_TEXT",
+			property: raw_client.FieldProperty{
+				Type:  "SINGLE_LINE_TEXT",
+				Code:  "text-1",
+				Label: "🍣🍺",
+			},
+		},
+		{
+			title: "NUMBER",
+			property: raw_client.FieldProperty{
+				Type:  "NUMBER",
+				Code:  "number-1",
+				Label: "🍣🍺",
+			},
+		},
+		{
+			title: "Unknown type",
+			property: raw_client.FieldProperty{
+				Type:  "ABCDEFG",
+				Code:  "xxx-1",
+				Label: "🍣🍺",
+			},
+			shouldBeError: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.title, func(t *testing.T) {
+			mapper := fieldPropertyMapper{}
+			f, err := mapper.PropertyToField(&tt.property)
+			if tt.shouldBeError {
+				if err == nil {
+					t.Fatalf("expected: error, actual: no errors")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("error: %+v", err)
+			}
+
+			property := mapper.FieldToProperty(f)
+			if !reflect.DeepEqual(property, tt.property) {
+				t.Fatalf("property != tt.property: property=%+v, tt.property=%+v", property, tt.property)
+			}
+		})
+	}
+}

--- a/kintone/fetch_application_usecase.go
+++ b/kintone/fetch_application_usecase.go
@@ -22,9 +22,7 @@ func (uc *FetchApplicationUseCase) Execute(ctx context.Context, cmd FetchApplica
 
 	var handleFields []Field
 	for _, f := range app.Fields {
-		if f.Type() == FieldSingleLineText || f.Type() == FieldNumber {
-			handleFields = append(handleFields, f)
-		}
+		handleFields = append(handleFields, f)
 	}
 	app.Fields = handleFields
 	return app, nil

--- a/kintone/fetch_application_usecase.go
+++ b/kintone/fetch_application_usecase.go
@@ -22,8 +22,7 @@ func (uc *FetchApplicationUseCase) Execute(ctx context.Context, cmd FetchApplica
 
 	var handleFields []Field
 	for _, f := range app.Fields {
-		if f.FieldType == FieldSingleLineText ||
-			f.FieldType == FieldNumber {
+		if f.Type() == FieldSingleLineText || f.Type() == FieldNumber {
 			handleFields = append(handleFields, f)
 		}
 	}

--- a/kintone/field.go
+++ b/kintone/field.go
@@ -4,6 +4,7 @@ type FieldType string
 
 const (
 	FieldSingleLineText = "SINGLE_LINE_TEXT"
+	FieldMultiLineText  = "MULTI_LINE_TEXT"
 	FieldNumber         = "NUMBER"
 )
 

--- a/kintone/field.go
+++ b/kintone/field.go
@@ -17,8 +17,8 @@ func (fc FieldCode) String() string {
 	return string(fc)
 }
 
-type Field struct {
-	Code      FieldCode
-	Label     string
-	FieldType FieldType
+type Field interface {
+	Type() FieldType
+	Code() FieldCode
+	Label() string
 }

--- a/kintone/field/multi_line_text.go
+++ b/kintone/field/multi_line_text.go
@@ -1,0 +1,27 @@
+package field
+
+import "github.com/naruta/terraform-provider-kintone/kintone"
+
+type MultiLineText struct {
+	code  kintone.FieldCode
+	label string
+}
+
+func NewMultiLineText(code kintone.FieldCode, label string) *MultiLineText {
+	return &MultiLineText{
+		code:  code,
+		label: label,
+	}
+}
+
+func (s *MultiLineText) Type() kintone.FieldType {
+	return "MULTI_LINE_TEXT"
+}
+
+func (s *MultiLineText) Code() kintone.FieldCode {
+	return s.code
+}
+
+func (s *MultiLineText) Label() string {
+	return s.label
+}

--- a/kintone/field/number.go
+++ b/kintone/field/number.go
@@ -1,0 +1,27 @@
+package field
+
+import "github.com/naruta/terraform-provider-kintone/kintone"
+
+type Number struct {
+	code  kintone.FieldCode
+	label string
+}
+
+func NewNumber(code kintone.FieldCode, label string) *Number {
+	return &Number{
+		code:  code,
+		label: label,
+	}
+}
+
+func (s *Number) Type() kintone.FieldType {
+	return "NUMBER"
+}
+
+func (s *Number) Code() kintone.FieldCode {
+	return s.code
+}
+
+func (s *Number) Label() string {
+	return s.label
+}

--- a/kintone/field/single_line_text.go
+++ b/kintone/field/single_line_text.go
@@ -1,0 +1,27 @@
+package field
+
+import "github.com/naruta/terraform-provider-kintone/kintone"
+
+type SingleLineText struct {
+	code  kintone.FieldCode
+	label string
+}
+
+func NewSingleLineText(code kintone.FieldCode, label string) *SingleLineText {
+	return &SingleLineText{
+		code:  code,
+		label: label,
+	}
+}
+
+func (s *SingleLineText) Type() kintone.FieldType {
+	return "SINGLE_LINE_TEXT"
+}
+
+func (s *SingleLineText) Code() kintone.FieldCode {
+	return s.code
+}
+
+func (s *SingleLineText) Label() string {
+	return s.label
+}

--- a/kintone/raw_client/field_property.go
+++ b/kintone/raw_client/field_property.go
@@ -1,0 +1,7 @@
+package raw_client
+
+type FieldProperty struct {
+	Code  string `json:"code"`
+	Label string `json:"label"`
+	Type  string `json:"type"`
+}

--- a/kintone/raw_client/get_app_form_fields.go
+++ b/kintone/raw_client/get_app_form_fields.go
@@ -14,9 +14,7 @@ type GetAppFormFieldsResponse struct {
 }
 
 type GetAppFormFieldsRequestProperty struct {
-	Code  string `json:"code"`
-	Label string `json:"label"`
-	Type  string `json:"type"`
+	FieldProperty
 }
 
 func GetAppFormFields(ctx context.Context, apiClient *ApiClient, req GetAppFormFieldsRequest) (*GetAppFormFieldsResponse, error) {

--- a/kintone/raw_client/post_preview_app_form_fields.go
+++ b/kintone/raw_client/post_preview_app_form_fields.go
@@ -3,9 +3,7 @@ package raw_client
 import "context"
 
 type PostPreviewAppFormFieldsRequestProperty struct {
-	Code  string `json:"code"`
-	Label string `json:"label"`
-	Type  string `json:"type"`
+	FieldProperty
 }
 
 type PostPreviewAppFormFieldsRequest struct {

--- a/kintone/raw_client/put_preview_app_form_fields.go
+++ b/kintone/raw_client/put_preview_app_form_fields.go
@@ -3,9 +3,7 @@ package raw_client
 import "context"
 
 type PutPreviewAppFormFieldsRequestProperty struct {
-	Code  string `json:"code"`
-	Label string `json:"label"`
-	Type  string `json:"type"`
+	FieldProperty
 }
 
 type PutPreviewAppFormFieldsRequest struct {

--- a/terraform_kintone/field_schema_mapper.go
+++ b/terraform_kintone/field_schema_mapper.go
@@ -15,6 +15,8 @@ func (m *fieldSchemaMapper) SchemaToField(fieldMap map[string]interface{}) (kint
 	switch fieldType {
 	case "SINGLE_LINE_TEXT":
 		return field.NewSingleLineText(code, label), nil
+	case "MULTI_LINE_TEXT":
+		return field.NewMultiLineText(code, label), nil
 	case "NUMBER":
 		return field.NewNumber(code, label), nil
 	default:

--- a/terraform_kintone/field_schema_mapper.go
+++ b/terraform_kintone/field_schema_mapper.go
@@ -1,0 +1,31 @@
+package terraform_kintone
+
+import (
+	"github.com/naruta/terraform-provider-kintone/kintone"
+	"github.com/naruta/terraform-provider-kintone/kintone/field"
+	"github.com/pkg/errors"
+)
+
+type fieldSchemaMapper struct{}
+
+func (m *fieldSchemaMapper) SchemaToField(fieldMap map[string]interface{}) (kintone.Field, error) {
+	fieldType := kintone.FieldType(fieldMap["type"].(string))
+	code := kintone.FieldCode(fieldMap["code"].(string))
+	label := fieldMap["label"].(string)
+	switch fieldType {
+	case "SINGLE_LINE_TEXT":
+		return field.NewSingleLineText(code, label), nil
+	case "NUMBER":
+		return field.NewNumber(code, label), nil
+	default:
+		return nil, errors.Errorf("unknown field type: %s", fieldType)
+	}
+}
+
+func (m *fieldSchemaMapper) FieldToSchema(f kintone.Field) map[string]interface{} {
+	return map[string]interface{}{
+		"code":  f.Code().String(),
+		"label": f.Label(),
+		"type":  f.Type().String(),
+	}
+}

--- a/terraform_kintone/field_schema_mapper_test.go
+++ b/terraform_kintone/field_schema_mapper_test.go
@@ -20,6 +20,14 @@ func TestFieldSchemaMapper(t *testing.T) {
 			},
 		},
 		{
+			title: "MULTI_LINE_TEXT",
+			fieldMap: map[string]interface{}{
+				"type":  "MULTI_LINE_TEXT",
+				"code":  "text-2",
+				"label": "🍣🍺",
+			},
+		},
+		{
 			title: "NUMBER",
 			fieldMap: map[string]interface{}{
 				"type":  "NUMBER",

--- a/terraform_kintone/field_schema_mapper_test.go
+++ b/terraform_kintone/field_schema_mapper_test.go
@@ -1,0 +1,61 @@
+package terraform_kintone
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFieldSchemaMapper(t *testing.T) {
+	testCases := []struct {
+		title         string
+		fieldMap      map[string]interface{}
+		shouldBeError bool
+	}{
+		{
+			title: "SINGLE_LINE_TEXT",
+			fieldMap: map[string]interface{}{
+				"type":  "SINGLE_LINE_TEXT",
+				"code":  "text-1",
+				"label": "🍣🍺",
+			},
+		},
+		{
+			title: "NUMBER",
+			fieldMap: map[string]interface{}{
+				"type":  "NUMBER",
+				"code":  "number-1",
+				"label": "🍣🍺",
+			},
+		},
+		{
+			title: "Unknown type",
+			fieldMap: map[string]interface{}{
+				"type":  "ABCDEFG",
+				"code":  "xxx-1",
+				"label": "🍣🍺",
+			},
+			shouldBeError: true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.title, func(t *testing.T) {
+			mapper := fieldSchemaMapper{}
+			f, err := mapper.SchemaToField(tt.fieldMap)
+			if tt.shouldBeError {
+				if err == nil {
+					t.Fatalf("expected: error, actual: no errors")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("error: %+v", err)
+			}
+
+			fieldMap := mapper.FieldToSchema(f)
+			if !reflect.DeepEqual(fieldMap, tt.fieldMap) {
+				t.Fatalf("fieldMap != tt.fieldMap: fieldMap=%+v, tt.fieldMap=%+v", fieldMap, tt.fieldMap)
+			}
+		})
+	}
+}

--- a/terraform_kintone/resource_kintone_application.go
+++ b/terraform_kintone/resource_kintone_application.go
@@ -60,6 +60,7 @@ func resourceKintoneApplication() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{
 								kintone.FieldSingleLineText,
 								kintone.FieldNumber,
+								kintone.FieldMultiLineText,
 							}, false),
 						},
 					},


### PR DESCRIPTION
This PR includes also code refactoring:

* Make `kintone.Field` interface
* Introduce `fieldPropertyMapper` and `fieldSchemaMapper`
     * These are used to convert between `Field` and `xxxProperty`, and between `Field` and `schema.Set`